### PR TITLE
Add Conceal HL group

### DIFF
--- a/colors/oceanicnext.vim
+++ b/colors/oceanicnext.vim
@@ -220,6 +220,7 @@ endif
 hi! link FoldColumn LineNr
 hi! link SignColumn LineNr
 call s:HL("ColorColumn", s:none, s:bg2)
+hi! link Conceal OcLilac
 call s:HL("Cursor", s:fg, s:none, "inverse")
 hi! link vCursor Cursor
 hi! link iCursor Cursor


### PR DESCRIPTION
The Conceal group was missing (`:h hl-Conceal`) which resulted in using a default that was a gray color.